### PR TITLE
chore(CI): Fix build job by testing installation of different specific versions of odo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ["2.0.0", "2.5.1", "3.0.0-beta3", "3.0.0-rc1"]
+        version: ["2.5.1", "3.0.0-rc2", "3.15.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -208,8 +208,8 @@ jobs:
       - name: Install Golang (for installing odo from Git refs)
         run: |
           asdf plugin-add golang https://github.com/kennyp/asdf-golang.git
-          asdf install golang 1.17.13
-          asdf global golang 1.17.13
+          asdf install golang 1.19.13
+          asdf global golang 1.19.13
 
       - name: Install plugin manually
         run: |
@@ -262,8 +262,8 @@ jobs:
       - name: Install Golang (for installing odo from Git refs)
         run: |
           asdf plugin-add golang https://github.com/kennyp/asdf-golang.git
-          asdf install golang 1.17.13
-          asdf global golang 1.17.13
+          asdf install golang 1.19.13
+          asdf global golang 1.19.13
 
       - name: Install plugin manually
         run: |


### PR DESCRIPTION
## Description

Test was failing on macos-latest because it appeared there was no binary for darwin-arm64 on the distribution website

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

