### PR TITLE
fix: Fix download URL for nightly builds of odo

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -10,7 +10,7 @@ GH_REPO="https://github.com/redhat-developer/odo"
 TOOL_NAME="odo"
 TOOL_TEST="odo version"
 BASE_DL_URL="https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/$TOOL_NAME"
-NIGHTLY_BASE_DL_URL="https://s3.us-south.cloud-object-storage.appdomain.cloud/odo-nightly/$TOOL_NAME-nightly"
+NIGHTLY_BASE_DL_URL="https://s3.us-south.cloud-object-storage.appdomain.cloud/${TOOL_NAME}-nightly"
 
 ansi() {
   if [ -n "$TERM" ]; then

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -10,7 +10,7 @@ GH_REPO="https://github.com/redhat-developer/odo"
 TOOL_NAME="odo"
 TOOL_TEST="odo version"
 BASE_DL_URL="https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/$TOOL_NAME"
-NIGHTLY_BASE_DL_URL="https://s3.us-south.cloud-object-storage.appdomain.cloud/odo-nightly/$TOOL_NAME-nightly-builds"
+NIGHTLY_BASE_DL_URL="https://s3.us-south.cloud-object-storage.appdomain.cloud/odo-nightly/$TOOL_NAME-nightly"
 
 ansi() {
   if [ -n "$TERM" ]; then

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -10,7 +10,7 @@ GH_REPO="https://github.com/redhat-developer/odo"
 TOOL_NAME="odo"
 TOOL_TEST="odo version"
 BASE_DL_URL="https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/$TOOL_NAME"
-NIGHTLY_BASE_DL_URL="https://s3.eu-de.cloud-object-storage.appdomain.cloud/$TOOL_NAME-nightly-builds"
+NIGHTLY_BASE_DL_URL="https://s3.us-south.cloud-object-storage.appdomain.cloud/odo-nightly/$TOOL_NAME-nightly-builds"
 
 ansi() {
   if [ -n "$TERM" ]; then


### PR DESCRIPTION
The nightly builds location has changed: https://odo.dev/docs/overview/installation/#nightly-builds